### PR TITLE
Remove the stats endpoint. Golang 1.10.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-    - 1.9
+    - "1.10.x"
 
 before_install:
   - make prepare

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ VOLUME [ "/etc/krakend" ]
 ENTRYPOINT [ "/usr/bin/krakend" ]
 CMD [ "run", "-c", "/etc/krakend/krakend.json" ]
 
-EXPOSE 8080
+EXPOSE 8000 8090

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -130,7 +130,7 @@
     "gin",
     "mux"
   ]
-  revision = "208fe67a6129789936e58eda7c4bc6d205943f4f"
+  revision = "96c245e74ec40ba0f3bcef9d386e042c793c44fc"
 
 [[projects]]
   branch = "master"

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ build:
 
 docker_build:
 	docker run --rm -it -e "GOPATH=/go" -v "${PWD}:/go/${GOBASEDIR}" -w /go/${GOBASEDIR} lushdigital/docker-golang-dep ensure -v
-	docker run --rm -it -e "GOPATH=/go" -p 8080:8080 -v "${PWD}:/go/${GOBASEDIR}" -w /go/${GOBASEDIR} golang:1.9.2 make build
+	docker run --rm -it -e "GOPATH=/go" -p 8080:8080 -v "${PWD}:/go/${GOBASEDIR}" -w /go/${GOBASEDIR} golang:1.10.2 make build
 
 docker_build_alpine:
 	docker build -t krakend_alpine_compiler builder/alpine

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ http://www.krakend.io/docs/overview/introduction/
 
 ## Build Requirements
 
-- golang 1.9
+- golang 1.10
 - `dep`
 
 ## Build

--- a/builder/alpine/Dockerfile
+++ b/builder/alpine/Dockerfile
@@ -1,3 +1,3 @@
-FROM golang:1.9.2-alpine3.7
+FROM golang:1.10.2-alpine3.7
 
 RUN apk add --no-cache make curl git build-base

--- a/executor.go
+++ b/executor.go
@@ -46,7 +46,7 @@ func NewExecutor(ctx context.Context) cmd.Executor {
 
 		// setup the krakend router
 		routerFactory := router.NewFactory(router.Config{
-			Engine:         NewEngine(cfg, logger, metricCollector),
+			Engine:         NewEngine(cfg, logger),
 			ProxyFactory:   NewProxyFactory(logger, NewBackendFactory(logger, metricCollector), metricCollector),
 			Middlewares:    []gin.HandlerFunc{},
 			Logger:         logger,

--- a/krakend.json
+++ b/krakend.json
@@ -15,7 +15,9 @@
         "collection_time": "60s",
         "proxy_disabled": false,
         "router_disabled": false,
-        "backend_disabled": false
+        "backend_disabled": false,
+        "endpoint_disabled": false,
+        "listen_address": ":8090"
       }
     },
     "endpoints": [

--- a/router_engine.go
+++ b/router_engine.go
@@ -2,14 +2,13 @@ package main
 
 import (
 	httpsecure "github.com/devopsfaith/krakend-httpsecure/gin"
-	metricsgin "github.com/devopsfaith/krakend-metrics/gin"
 	"github.com/devopsfaith/krakend/config"
 	"github.com/devopsfaith/krakend/logging"
 	"github.com/gin-gonic/gin"
 )
 
-// NewEngine creates a new gin engine with some default values, a secure middleware and an stats endpoint
-func NewEngine(cfg config.ServiceConfig, logger logging.Logger, metricCollector *metricsgin.Metrics) *gin.Engine {
+// NewEngine creates a new gin engine with some default values and a secure middleware
+func NewEngine(cfg config.ServiceConfig, logger logging.Logger) *gin.Engine {
 	engine := gin.Default()
 
 	engine.RedirectTrailingSlash = true
@@ -19,8 +18,6 @@ func NewEngine(cfg config.ServiceConfig, logger logging.Logger, metricCollector 
 	if err := httpsecure.Register(cfg.ExtraConfig, engine); err != nil {
 		logger.Error(err)
 	}
-
-	engine.GET("/__stats/", metricCollector.NewExpHandler())
 
 	return engine
 }


### PR DESCRIPTION
Since it's already provided in the new krakend-metrics middleware.
It also updates golang to 1.10.2 and fix the Dockerfile.