### PR TITLE
Log information update

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -72,7 +72,7 @@
   version = "v0.2.0"
 
 [[projects]]
-  digest = "1:ad619f6e320fdcaadf3aa3d8872b431b13f8ea80634e057756b7f47ea1311921"
+  digest = "1:855c662a17de7709f7497a133d5290fd180c436d55a9d7a7678c4d038988edd6"
   name = "github.com/devopsfaith/bloomfilter"
   packages = [
     ".",
@@ -83,8 +83,8 @@
     "rpc/server",
   ]
   pruneopts = ""
-  revision = "1ecce393f4fa21b7999d01b399be20f4daaff817"
-  version = "0.6.1"
+  revision = "662332d04f21bae2540078902d1bbf20785f8ebc"
+  version = "0.7.0"
 
 [[projects]]
   digest = "1:abbc53b4bbfce768031ac374d664d91f8c782bb0d7cf1847b251d26aca7fba57"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -92,7 +92,7 @@
   name = "github.com/devopsfaith/krakend-jose"
 
 [[constraint]]
-  version = "0.6.1"
+  version = "0.7.0"
   name = "github.com/devopsfaith/bloomfilter"
 
 [[constraint]]

--- a/executor.go
+++ b/executor.go
@@ -31,7 +31,7 @@ func NewExecutor(ctx context.Context) cmd.Executor {
 			if err != nil {
 				return
 			}
-			logger.Error("unable to create the gologgin logger:", gologgingErr.Error())
+			logger.Error("unable to create the gologging logger:", gologgingErr.Error())
 		}
 
 		logger.Info("Listening on port:", cfg.Port)
@@ -42,17 +42,16 @@ func NewExecutor(ctx context.Context) cmd.Executor {
 		metricCollector := metrics.New(ctx, cfg.ExtraConfig, logger)
 
 		if err := influxdb.New(ctx, cfg.ExtraConfig, metricCollector, logger); err != nil {
-			logger.Error(err.Error())
+			logger.Warning(err.Error())
 		}
 
 		if err := opencensus.Register(ctx, cfg); err != nil {
-			logger.Error("opencensus:", err.Error())
+			logger.Warning("opencensus:", err.Error())
 		}
 
 		rejecter, err := krakendbf.Register(ctx, "krakend-bf", cfg, logger, reg)
-		// rejecter, err := krakendbf.Register(ctx, cfg.Name, cfg, logger, reg)
 		if err != nil {
-			logger.Error("registering the BloomFilter:", err.Error())
+			logger.Warning("registering the BloomFilter:", err.Error())
 		}
 
 		// setup the krakend router

--- a/executor.go
+++ b/executor.go
@@ -34,6 +34,8 @@ func NewExecutor(ctx context.Context) cmd.Executor {
 			logger.Error("unable to create the gologgin logger:", gologgingErr.Error())
 		}
 
+		logger.Info("Listening on port:", cfg.Port)
+
 		reg := RegisterSubscriberFactories(ctx, cfg, logger)
 
 		// create the metrics collector


### PR DESCRIPTION
Update middleware logs to Warning (instead of Error).
Add information about the port used.
Update the bloomfilter package to fix it's log output.