### PR TITLE
etcd client upgraded to v3.3

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -895,12 +895,12 @@
   revision = "3918361d3e9781714bbdb3ad9c11de4fa5c73d34"
 
 [[projects]]
-  branch = "master"
-  digest = "1:e500a14b76b36e44dfeb4b8c89ebca466d148712be5c4457e72080a83d915e32"
+  digest = "1:2e7f653483e51243b6cd6de60ce39bde0d6927d10a3c24295ab0f82cb1efeae2"
   name = "github.com/ugorji/go"
   packages = ["codec"]
   pruneopts = ""
-  revision = "f0aa215a7d653544d39d0e27dfa10fa4b183f397"
+  revision = "b4c50a2b199d93b13dc15e78929cfb23bfdf21ab"
+  version = "v1.1.1"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -133,7 +133,7 @@
   version = "v1.8"
 
 [[projects]]
-  digest = "1:0f98300e315a38eb5b71615acf600ccb82fa82dffe76304802dd6afb3325f5d5"
+  digest = "1:0bc9fe59e23786a6d5f5b65d2676904d29aafcc79fa9fca4472fe0d15ee15656"
   name = "github.com/coreos/etcd"
   packages = [
     "client",
@@ -143,7 +143,8 @@
     "version",
   ]
   pruneopts = ""
-  revision = "7e79c257cab156a511315b5e3459b4f88ecfe622"
+  revision = "d57e8b8d97adfc4a6c224fe116714bf1a1f3beb9"
+  version = "v3.3.12"
 
 [[projects]]
   digest = "1:3c3f68ebab415344aef64363d23471e953a4715645115604aaf57923ae904f5e"
@@ -283,7 +284,10 @@
 [[projects]]
   digest = "1:1e2f409ee9b67754643c462adaa1791fff3a1211912c7487d2fad15b6c68a6eb"
   name = "github.com/devopsfaith/krakend-jose"
-  packages = ["."]
+  packages = [
+    ".",
+    "gin",
+  ]
   pruneopts = ""
   revision = "09f07ba6c926bfa901d17490864c8f78fbb46a0e"
   version = "0.8.0"
@@ -1212,6 +1216,7 @@
     "github.com/devopsfaith/krakend-httpcache",
     "github.com/devopsfaith/krakend-httpsecure/gin",
     "github.com/devopsfaith/krakend-jose",
+    "github.com/devopsfaith/krakend-jose/gin",
     "github.com/devopsfaith/krakend-jsonschema",
     "github.com/devopsfaith/krakend-logstash",
     "github.com/devopsfaith/krakend-martian",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -9,7 +9,7 @@
 
 [[override]]
   name = "github.com/coreos/etcd"
-  revision = "7e79c257cab156a511315b5e3459b4f88ecfe622"
+  version = "3.3.12"
 
 [[override]]
   version = "0.7.0"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -8,6 +8,10 @@
   revision = "140c935a5d0d15e2cdc24b1f58668f410497fc3c"
 
 [[override]]
+  version = "=1.1.1"
+  name = "github.com/ugorji/go"
+
+[[override]]
   name = "github.com/coreos/etcd"
   version = "3.3.12"
 


### PR DESCRIPTION
as requested at #72, this PR upgrades the etcd client to the v3.3.12 while still using the `github.com/coreos/etcd/client` package instead of `github.com/coreos/etcd/clientv3`