### PR TITLE
xml render

### DIFF
--- a/encoding.go
+++ b/encoding.go
@@ -3,10 +3,14 @@ package krakend
 import (
 	"github.com/devopsfaith/krakend-rss"
 	"github.com/devopsfaith/krakend-xml"
+	ginxml "github.com/devopsfaith/krakend-xml/gin"
+	"github.com/devopsfaith/krakend/router/gin"
 )
 
 // RegisterEncoders registers all the available encoders
 func RegisterEncoders() {
 	xml.Register()
 	rss.Register()
+
+	gin.RegisterRender(xml.Name, ginxml.Render)
 }

--- a/go.mod
+++ b/go.mod
@@ -55,7 +55,7 @@ require (
 	github.com/devopsfaith/krakend-rss v0.0.0-20180408220939-4c18c62a99ee
 	github.com/devopsfaith/krakend-usage v0.0.0-20181025134340-476779c0a36c
 	github.com/devopsfaith/krakend-viper v0.0.0-20190407170411-1cbb76813774
-	github.com/devopsfaith/krakend-xml v0.0.0-20190709144612-0cd19aeb1104
+	github.com/devopsfaith/krakend-xml v0.0.0-20190713155104-2cd38185308f
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/fsnotify/fsnotify v1.4.7
 	github.com/gin-contrib/sse v0.0.0-20190301062529-5545eab6dad3

--- a/go.sum
+++ b/go.sum
@@ -276,6 +276,8 @@ github.com/devopsfaith/krakend-xml v0.0.0-20180408220837-5ce94062a4cc h1:wnzsw3U
 github.com/devopsfaith/krakend-xml v0.0.0-20180408220837-5ce94062a4cc/go.mod h1:xyNKiNHdl5WY/CiUyWJgmx4hdzwT+lLInGKj7qio5d4=
 github.com/devopsfaith/krakend-xml v0.0.0-20190709144612-0cd19aeb1104 h1:NobQ2b0qTIUfByKVQDz4q64lfwmi7+HQ3b+aEEoJz/Q=
 github.com/devopsfaith/krakend-xml v0.0.0-20190709144612-0cd19aeb1104/go.mod h1:xyNKiNHdl5WY/CiUyWJgmx4hdzwT+lLInGKj7qio5d4=
+github.com/devopsfaith/krakend-xml v0.0.0-20190713155104-2cd38185308f h1:wyDziW3fHGpAFDWk+8C2xRP284lqZr8qPVb30uq37vo=
+github.com/devopsfaith/krakend-xml v0.0.0-20190713155104-2cd38185308f/go.mod h1:xyNKiNHdl5WY/CiUyWJgmx4hdzwT+lLInGKj7qio5d4=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-bitstream v0.0.0-20180413035011-3522498ce2c8/go.mod h1:VMaSuZ+SZcx/wljOQKvp5srsbCiKDEb6K2wC4+PiBmQ=

--- a/tests/fixtures/krakend.json
+++ b/tests/fixtures/krakend.json
@@ -54,6 +54,27 @@
             ]
         },
         {
+            "endpoint": "/xml/xml",
+            "output_encoding": "xml",
+            "backend": [
+                {
+                    "host": [ "http://127.0.0.1:8081" ],
+                    "url_pattern": "/xml",
+                    "encoding": "xml"
+                }
+            ]
+        },
+        {
+            "endpoint": "/xml/json",
+            "output_encoding": "xml",
+            "backend": [
+                {
+                    "host": [ "http://127.0.0.1:8081" ],
+                    "url_pattern": "/param_forwarding"
+                }
+            ]
+        },
+        {
             "endpoint": "/negotiate",
             "method": "GET",
             "output_encoding": "negotiate",

--- a/tests/fixtures/specs/xml_1.json
+++ b/tests/fixtures/specs/xml_1.json
@@ -1,0 +1,15 @@
+{
+	"in": {
+		"method": "GET",
+		"url": "http://localhost:8080/xml/xml"
+	},
+	"out": {
+		"status_code": 200,
+		"body": "<user type=\"admin\"><name>Elliot</name><social><facebook>https://facebook.com</facebook><twitter>https://twitter.com</twitter><youtube>https://youtube.com</youtube></social></user>",
+		"header": {
+			"content-type": "application/xml",
+			"Cache-Control": "public, max-age=3600",
+			"X-Krakend-Completed": "true"
+		}
+	}
+}

--- a/tests/fixtures/specs/xml_2.json
+++ b/tests/fixtures/specs/xml_2.json
@@ -1,0 +1,15 @@
+{
+	"in": {
+		"method": "GET",
+		"url": "http://localhost:8080/xml/json"
+	},
+	"out": {
+		"status_code": 200,
+		"body": "<doc><foo>42</foo><headers><Accept-Encoding>gzip</Accept-Encoding><Referer>http://127.0.0.1:8081/param_forwarding</Referer><User-Agent>KrakenD Version 0.10.0-dev</User-Agent></headers><path>/param_forwarding/</path><query/></doc>",
+		"header": {
+			"content-type": "application/xml",
+			"Cache-Control": "public, max-age=3600",
+			"X-Krakend-Completed": "true"
+		}
+	}
+}


### PR DESCRIPTION
The `negotiate` render uses the `encoding/xml` pkg from the stdlib, making it hard for the gateway to return XML generated from maps of interfaces. This PR registers a `xml` render using the mxj lib making it possible to return any response as XML