### PR TITLE
Link the gin debug mode to the debug flag

### DIFF
--- a/router_engine.go
+++ b/router_engine.go
@@ -14,6 +14,10 @@ import (
 
 // NewEngine creates a new gin engine with some default values and a secure middleware
 func NewEngine(cfg config.ServiceConfig, logger logging.Logger, w io.Writer) *gin.Engine {
+	if !cfg.Debug {
+		gin.SetMode(gin.ReleaseMode)
+	}
+
 	engine := gin.New()
 	engine.Use(gin.LoggerWithConfig(gin.LoggerConfig{Output: w}), gin.Recovery())
 


### PR DESCRIPTION
when running the gateway without the `-d` flag, the gin router must be set to 'release'