### PR TITLE
Fix #177 Added Debian as a main image builder for `krakend`, updated alpine builder and version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,13 @@
-FROM alpine:3.10
+FROM debian:buster
 
 LABEL maintainer="dortiz@devops.faith"
 
-RUN apk add --no-cache ca-certificates
-ADD krakend-alpine /usr/bin/krakend
+RUN apt-get update && \
+	apt-get install -y ca-certificates && \
+	update-ca-certificates && \
+	rm -rf /var/lib/apt/lists/*
+
+ADD krakend /usr/bin/krakend
 
 VOLUME [ "/etc/krakend" ]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster
+FROM debian:buster-slim
 
 LABEL maintainer="dortiz@devops.faith"
 

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,0 +1,22 @@
+FROM golang:1.13.1-alpine3.10 as builder
+
+WORKDIR /app
+
+RUN apk add --no-cache make curl git build-base
+
+COPY . .
+
+RUN make build
+
+FROM alpine:3.10
+
+LABEL maintainer="dortiz@devops.faith"
+
+COPY --from=builder /app/krakend /usr/bin/krakend
+
+VOLUME [ "/etc/krakend" ]
+
+ENTRYPOINT [ "/usr/bin/krakend" ]
+CMD [ "run", "-c", "/etc/krakend/krakend.json" ]
+
+EXPOSE 8000 8090

--- a/Makefile
+++ b/Makefile
@@ -59,12 +59,7 @@ test: build
 docker_build:
 	docker run --rm -it -v "${PWD}:/app" -w /app golang:${GOLANG_VERSION} make build
 
-docker_build_alpine:
-	docker build -t krakend_alpine_compiler builder/alpine
-	docker run --rm -it -e "BIN_NAME=krakend-alpine" -v "${PWD}:/app" -w /app krakend_alpine_compiler make -e build
-
-krakend_docker:
-	@echo "You need to compile krakend using 'make docker_build_alpine' to build this container."
+krakend_docker: docker_build
 	docker build -t devopsfaith/krakend:${VERSION} .
 
 tgz: builder/skel/tgz/usr/bin/krakend

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,9 @@ docker_build:
 krakend_docker: docker_build
 	docker build -t devopsfaith/krakend:${VERSION} .
 
+krakend_docker_alpine:
+	docker build -t devopsfaith/krakend:${VERSION}-alpine -f Dockerfile.alpine .
+
 tgz: builder/skel/tgz/usr/bin/krakend
 tgz: builder/skel/tgz/etc/krakend/krakend.json
 tgz: builder/skel/tgz/etc/init.d/krakend

--- a/builder/alpine/Dockerfile
+++ b/builder/alpine/Dockerfile
@@ -1,3 +1,0 @@
-FROM golang:1.13.1-alpine3.10
-
-RUN apk add --no-cache make curl git build-base


### PR DESCRIPTION
There is a fix for a problem #177 when krakend with custom plugin could not be started.
Developers in #krakend slack channel noticed that replace alpine to another distro helps with this issue. I've dropped alpine support and replace it to debian:buster.
It slightly increases docker image size, but makes plugins work.
