### PR TITLE
better error reporting added to the integration test runner

### DIFF
--- a/cmd/krakend-integration/main.go
+++ b/cmd/krakend-integration/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"os"
 
 	"github.com/devopsfaith/krakend-ce/tests"
 )
@@ -13,16 +14,27 @@ func main() {
 	runner, tcs, err := tests.NewIntegration(nil, nil, nil)
 	if err != nil {
 		fmt.Println(err)
+		os.Exit(1)
 		return
 	}
 	defer runner.Close()
 
+	errors := 0
+
 	for _, tc := range tcs {
 		if err := runner.Check(tc); err != nil {
+			errors++
 			fmt.Printf("%s: %s\n", tc.Name, err.Error())
-			return
+			continue
 		}
 		fmt.Printf("%s: ok\n", tc.Name)
 	}
 	fmt.Printf("%d test completed\n", len(tcs))
+
+	if errors == 0 {
+		return
+	}
+
+	fmt.Printf("%d test failed\n", errors)
+	os.Exit(1)
 }


### PR DESCRIPTION
this PR improves the integration test runner by:

- returning a non zero exit code when an error is detected
- collecting all the errors before closing the test
- passing envars to the krakend instance under test (with filters)