### PR TITLE
enhanced gin config to allow urlencoded params

### DIFF
--- a/router_engine.go
+++ b/router_engine.go
@@ -23,6 +23,8 @@ func NewEngine(cfg config.ServiceConfig, logger logging.Logger, w io.Writer) *gi
 	engine.RedirectTrailingSlash = true
 	engine.RedirectFixedPath = true
 	engine.HandleMethodNotAllowed = true
+	engine.UseRawPath = true
+	engine.UnescapePathValues = false
 
 	if err := httpsecure.Register(cfg.ExtraConfig, engine); err != nil {
 		logger.Warning(err)

--- a/tests/fixtures/specs/param_forwarding_5.json
+++ b/tests/fixtures/specs/param_forwarding_5.json
@@ -1,0 +1,20 @@
+{
+	"in": {
+		"method": "GET",
+		"url": "http://localhost:8080/param_forwarding/some/foo%2Fwith%2Furlencode/bar?a=1&b=2",
+		"header": {
+			"Authorization": "bearer 123456",
+			"X-Y-Z": "true",
+			"A-B-C": "ignore"
+		}
+	},
+	"out": {
+		"status_code": 200,
+		"body": "{\"foo\":42,\"headers\":{\"Accept-Encoding\":[\"gzip\"],\"Authorization\":[\"bearer 123456\"],\"User-Agent\":[\"KrakenD Version 1.3.0\"],\"X-Forwarded-Host\":[\"localhost:8080\"],\"X-Y-Z\":[\"true\"]},\"path\":\"/param_forwarding/bar\",\"query\":{\"foo\":[\"foo/with/urlencode\"]}}",
+		"header": {
+			"content-type": ["application/json; charset=utf-8"],
+			"Cache-Control": ["public, max-age=3600"],
+			"X-Krakend-Completed": ["true"]
+		}
+	}
+}


### PR DESCRIPTION
Fixes a bug with urlencoded parameters when containing a url encoded /

https://github.com/devopsfaith/krakend-ce/issues/290