### PR TITLE
Disable IT http client to follow redirections

### DIFF
--- a/tests/fixtures/specs/cors_5.json
+++ b/tests/fixtures/specs/cors_5.json
@@ -1,7 +1,7 @@
 {
 	"in": {
 		"method": "GET",
-		"url": "http://localhost:8080/param_forwarding/some/foo//bar/",
+		"url": "http://localhost:8080/param_forwarding/some/foo/bar",
 		"header": {
 			"User-Agent": "some",
 			"Origin": "http://foo.example.tld"

--- a/tests/integration.go
+++ b/tests/integration.go
@@ -42,7 +42,7 @@ var (
 		"",
 		"Comma separated list of patterns to use to filter the envars to pass (set to \".*\" to pass everything)",
 	)
-	followRedirects = flag.Bool("client_follow_redirects", true, "Whether the test http client should follow http redirects or not")
+	notFollowRedirects = flag.Bool("client_not_follow_redirects", false, "The test http client should not follow http redirects")
 )
 
 // TestCase defines a single case to be tested
@@ -140,14 +140,14 @@ func (c *Config) getHttpClient() *http.Client {
 }
 
 func defaultHttpClient() *http.Client {
-	if *followRedirects {
-		return http.DefaultClient
+	if *notFollowRedirects {
+		return &http.Client{
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		}
 	}
-	return &http.Client{
-		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			return http.ErrUseLastResponse
-		},
-	}
+	return http.DefaultClient
 }
 
 var defaultConfig Config


### PR DESCRIPTION
Add a boolean flag `client_not_follow_redirects` to krakend-integration to allow the client not to follow http redirects