### PR TITLE
Declare expected response as either string or json object

### DIFF
--- a/tests/fixtures/specs/detail_error.json
+++ b/tests/fixtures/specs/detail_error.json
@@ -5,7 +5,20 @@
 	},
 	"out": {
 		"status_code": 200,
-		"body": "{\"error_backend_b\":{\"http_status_code\":404,\"http_body\":\"404 page not found\\n\"},\"foo\":42,\"headers\":{\"Accept-Encoding\":[\"gzip\"],\"User-Agent\":[\"KrakenD Version 1.4.1\"],\"X-Forwarded-Host\":[\"localhost:8080\"]},\"path\":\"/param_forwarding/\",\"query\":{}}",
+		"body": {
+          "error_backend_b": {
+            "http_status_code": 404,
+            "http_body": "404 page not found\n"
+          },
+          "foo": 42,
+          "headers": {
+            "Accept-Encoding": ["gzip"],
+            "User-Agent": ["KrakenD Version 1.4.1"],
+            "X-Forwarded-Host": ["localhost:8080"]
+          },
+          "path": "/param_forwarding/",
+          "query": {}
+        },
 		"header": {
 			"content-type": ["application/json; charset=utf-8"],
 			"Cache-Control": [""],


### PR DESCRIPTION
@kpacha if that makes sense to you I could update all test scenarios to be declared as json.

We have been using `krakend-integration` as a tool in our CI pipeline and it is sometimes inconvenient to define the response `Body` as string since it does full match. With this change json objects may be compared no matter how the keys are sorted.