### PR TITLE
incorrect make target for docker builds in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ https://www.krakend.io/docs/overview/introduction/
 
 If you don't have or don't want to install `go` you can build it using the golang docker container.
 ```
-make docker_build
+    make build_on_docker
 ```
 
 ## FPM


### PR DESCRIPTION
## About

The README says to use `make docker_build` to build the project with docker, but the correct command is `make build_on_docker`.