### PR TITLE
Declare krakend-integration input body as either string or object

### DIFF
--- a/tests/fixtures/specs/jsonschema_1.json
+++ b/tests/fixtures/specs/jsonschema_1.json
@@ -2,7 +2,9 @@
 	"in": {
 		"method": "POST",
 		"url": "http://localhost:8080/jsonschema",
-		"body": "{\"foo\":42}"
+		"body": {
+			"foo": 42
+		}
 	},
 	"out": {
 		"status_code": 400

--- a/tests/integration.go
+++ b/tests/integration.go
@@ -58,7 +58,7 @@ type Input struct {
 	URL    string            `json:"url"`
 	Method string            `json:"method"`
 	Header map[string]string `json:"header"`
-	Body   string            `json:"body"`
+	Body   interface{}       `json:"body"`
 }
 
 // Output contains the data required to verify the response received in a given TestCase
@@ -335,9 +335,18 @@ func parseTestCase(name string, in []byte) (TestCase, error) {
 
 func newRequest(in Input) (*http.Request, error) {
 	var body io.Reader
-	if in.Body != "" {
-		body = bytes.NewBufferString(in.Body)
+
+	if in.Body != nil {
+		var b []byte
+		switch in.Body.(type) {
+		case string:
+			b = []byte(in.Body.(string))
+		default:
+			b, _ = json.Marshal(in.Body)
+		}
+		body = bytes.NewBuffer(b)
 	}
+
 	req, err := http.NewRequest(in.Method, in.URL, body)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This PR aims to ease the declaration of integration tests using krakend-integration, `input.Body` may now be declared as string (escaping quotes) or as an embedded object.